### PR TITLE
Upgrading octokit gem to ~4.6 to support AbleCop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .byebug_history
+*.sw[a-zA-Z]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that you want performed for every review app in here.
 Include `planter` in your Gemfile:
 
 ```ruby
-gem "planter", git: "https://github.com/ableco/planter.git", tag: "v0.1.2"
+gem "planter", git: "https://github.com/ableco/planter.git", tag: "v0.1.3"
 ```
 
 And then execute:

--- a/lib/planter/version.rb
+++ b/lib/planter/version.rb
@@ -1,3 +1,3 @@
 module Planter
-  VERSION = "0.1.2".freeze
+  VERSION = "0.1.3".freeze
 end

--- a/planter.gemspec
+++ b/planter.gemspec
@@ -29,7 +29,7 @@ folder by running the following command:
 
 MSG
 
-  spec.add_runtime_dependency "octokit", "~> 4.3.0"
+  spec.add_runtime_dependency "octokit", "~> 4.6.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
When we're using [AbleCop](https://github.com/ableco/ablecop/issues/36) + Planter together we're running into problems. Upgrading the gem so we're supported for both version. Actually, we should probably change this to `>= 4.3.0` thoughts? That way we're not locked in by the minor patches.