### PR TITLE
Update octokit dependency to 4.6.2

### DIFF
--- a/planter.gemspec
+++ b/planter.gemspec
@@ -29,7 +29,7 @@ folder by running the following command:
 
 MSG
 
-  spec.add_runtime_dependency "octokit", "~> 4.3.0"
+  spec.add_runtime_dependency "octokit", "~> 4.6.2"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I recently updated [AbleCop](https://github.com/ableco/ablecop), and it was found that the gem dependencies in AbleCop clash with the dependencies in Planter, specifically the [Octokit gem](https://github.com/octokit/octokit.rb), so the recent version of AbleCop won't work in repos with Planter.

This pull request updates the dependency in the gemspec for Octokit to avoid this incompatibility. It should not break the place where Octokit is used in the gem.

On a side note, I tried to update the VCR cassettes to make double-check that the gem update doesn't break anything, but I couldn't do it since I don't see the test repo used in those specs anywhere, plus I don't have the access token for it. It's not necessary to update these specs but I would recommend doing so.