### PR TITLE
Update Octokit dependency and update gem version to 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that you want performed for every review app in here.
 Include `planter` in your Gemfile:
 
 ```ruby
-gem "planter", git: "https://github.com/ableco/planter.git", tag: "v0.1.3"
+gem "planter", git: "https://github.com/ableco/planter.git", tag: "v0.1.4"
 ```
 
 And then execute:

--- a/lib/planter/version.rb
+++ b/lib/planter/version.rb
@@ -1,3 +1,3 @@
 module Planter
-  VERSION = "0.1.3".freeze
+  VERSION = "0.1.4".freeze
 end

--- a/planter.gemspec
+++ b/planter.gemspec
@@ -29,7 +29,7 @@ folder by running the following command:
 
 MSG
 
-  spec.add_runtime_dependency "octokit", "~> 4.6.0"
+  spec.add_runtime_dependency "octokit", "~> 4.7.0"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This pull request updates the Octokit dependency to 4.7.0, and bumps up the version of the gem itself to 0.1.4 for a new release.

I made this change due to AbleCop needing this dependency after https://github.com/ableco/ablecop/pull/45 is merged and a new AbleCop release is made, so that the versions don't clash in the projects that are using both gems.